### PR TITLE
Added option to remove scrollbars from full screen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@
 * Krzysztof J. Kowalczyk  (http://blog.kowalczyk.info)
 * Ludo Brands
 * Matthew Wilcoxson (matthew.wilcoxson at gmail.com)
+* Mark Stobie
 * Nathan Jhaveri
 * Peter Astrand
 * Robert Liu

--- a/docs/settings.html
+++ b/docs/settings.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 
 <html>
 <head>
@@ -104,6 +104,9 @@ FixedPageUI [
     <span class=cm id="FixedPageUI_SelectionColor"><a href="#color">color</a> value for the text selection rectangle (also used to highlight found text) (introduced in 
     version 2.4)</span>
     SelectionColor = #f5fc0c
+
+    <span class=cm id="FixedPageUI_ShowScrollBarsInFullScreen">If false, while in full screen view the pages will occupy the entire area</span>
+    ShowScrollBarsInFullScreen = true
 
     <span class=cm id="FixedPageUI_WindowMargin">top, right, bottom and left margin (in that order) between window and document</span>
     WindowMargin = 2 4 2 4

--- a/src/Canvas.cpp
+++ b/src/Canvas.cpp
@@ -17,6 +17,8 @@ void ControllerCallbackHandler::UpdateScrollbars(SizeI canvas)
 
     SizeI viewPort = dm->GetViewPort().Size();
 
+	bool scrollBarsEnabled = !win->isFullScreen || gGlobalPrefs->fixedPageUI.showScrollBarsInFullScreen;
+
     if (viewPort.dx >= canvas.dx) {
         si.nPos = 0;
         si.nMin = 0;
@@ -28,7 +30,7 @@ void ControllerCallbackHandler::UpdateScrollbars(SizeI canvas)
         si.nMax = canvas.dx - 1;
         si.nPage = viewPort.dx;
     }
-    ShowScrollBar(win->hwndCanvas, SB_HORZ, viewPort.dx < canvas.dx);
+    ShowScrollBar(win->hwndCanvas, SB_HORZ, viewPort.dx < canvas.dx && scrollBarsEnabled);
     SetScrollInfo(win->hwndCanvas, SB_HORZ, &si, TRUE);
 
     if (viewPort.dy >= canvas.dy) {
@@ -48,7 +50,7 @@ void ControllerCallbackHandler::UpdateScrollbars(SizeI canvas)
             si.nMax -= viewPort.dy - si.nPage;
         }
     }
-    ShowScrollBar(win->hwndCanvas, SB_VERT, viewPort.dy < canvas.dy);
+    ShowScrollBar(win->hwndCanvas, SB_VERT, viewPort.dy < canvas.dy && scrollBarsEnabled);
     SetScrollInfo(win->hwndCanvas, SB_VERT, &si, TRUE);
 }
 

--- a/src/ChmModel.h
+++ b/src/ChmModel.h
@@ -33,6 +33,7 @@ public:
     virtual void SetDisplayMode(DisplayMode mode, bool keepContinuous=false) { /* not supported */ }
     virtual DisplayMode GetDisplayMode() const { return DM_SINGLE_PAGE; }
     virtual void SetPresentationMode(bool enable) { /* not supported */ }
+    virtual void SetFullScreenMode(bool enable) { /* not supported */ }
     virtual void SetZoomVirtual(float zoom, PointI *fixPt=NULL);
     virtual float GetZoomVirtual() const;
     virtual float GetNextZoomStep(float towards) const;

--- a/src/Controller.h
+++ b/src/Controller.h
@@ -69,6 +69,7 @@ public:
     virtual void SetDisplayMode(DisplayMode mode, bool keepContinuous=false) = 0;
     virtual DisplayMode GetDisplayMode() const = 0;
     virtual void SetPresentationMode(bool enable) = 0;
+    virtual void SetFullScreenMode(bool enable) = 0;
     virtual void SetZoomVirtual(float zoom, PointI *fixPt=NULL) = 0;
     virtual float GetZoomVirtual() const = 0;
     virtual float GetNextZoomStep(float towards) const = 0;

--- a/src/DisplayModel.h
+++ b/src/DisplayModel.h
@@ -84,6 +84,7 @@ public:
     virtual void SetDisplayMode(DisplayMode mode, bool keepContinuous=true);
     virtual DisplayMode GetDisplayMode() const { return displayMode; }
     virtual void SetPresentationMode(bool enable);
+    virtual void SetFullScreenMode(bool enable);
     virtual void SetZoomVirtual(float zoom, PointI *fixPt=NULL) { ZoomTo(zoom, fixPt); }
     virtual float GetZoomVirtual() const { return zoomVirtual; }
     virtual float GetNextZoomStep(float towards) const;
@@ -192,6 +193,7 @@ public:
     bool            dontRenderFlag;
 
     bool            GetPresentationMode() const { return presentationMode; }
+    bool            GetFullScreenMode() const { return fullScreenMode; }
 
 protected:
 
@@ -209,6 +211,7 @@ protected:
     void            GoToPage(int pageNo, int scrollY, bool addNavPt=false, int scrollX=-1);
     bool            GoToPrevPage(int scrollY);
     int             GetPageNextToPoint(PointI pt);
+    void            ReturnToStandardView();
 
     BaseEngine *    _engine;
 
@@ -250,6 +253,7 @@ protected:
     bool            presentationMode;
     float           presZoomVirtual;
     DisplayMode     presDisplayMode;
+    bool            fullScreenMode;
 
     Vec<ScrollState>navHistory;
     /* index of the "current" history entry (to be updated on navigation),

--- a/src/EbookController.h
+++ b/src/EbookController.h
@@ -38,6 +38,7 @@ public:
     virtual void SetDisplayMode(DisplayMode mode, bool keepContinuous=false);
     virtual DisplayMode GetDisplayMode() const { return IsDoublePage() ? DM_FACING : DM_SINGLE_PAGE; }
     virtual void SetPresentationMode(bool enable) { /* not supported */ }
+    virtual void SetFullScreenMode(bool enable) { /* not supported */ }
     virtual void SetZoomVirtual(float zoom, PointI *fixPt=NULL) { /* not supported */ }
     virtual float GetZoomVirtual() const { return 100; }
     virtual float GetNextZoomStep(float towards) const { return 100; }

--- a/src/SettingsStructs.h
+++ b/src/SettingsStructs.h
@@ -28,6 +28,9 @@ struct FixedPageUI {
     // color value for the text selection rectangle (also used to highlight
     // found text)
     COLORREF selectionColor;
+    // in full screen view the scroll bars won't be present and the entire
+    // screen will be filled with the pages.
+    bool showScrollBarsInFullScreen;
     // top, right, bottom and left margin (in that order) between window
     // and document
     WindowMargin windowMargin;
@@ -362,14 +365,15 @@ static const FieldInfo gSizeIFields[] = {
 static const StructInfo gSizeIInfo = { sizeof(SizeI), 2, gSizeIFields, "Dx\0Dy" };
 
 static const FieldInfo gFixedPageUIFields[] = {
-    { offsetof(FixedPageUI, textColor),       Type_Color,      0x000000                     },
-    { offsetof(FixedPageUI, backgroundColor), Type_Color,      0xffffff                     },
-    { offsetof(FixedPageUI, selectionColor),  Type_Color,      0x0cfcf5                     },
-    { offsetof(FixedPageUI, windowMargin),    Type_Compact,    (intptr_t)&gWindowMarginInfo },
-    { offsetof(FixedPageUI, pageSpacing),     Type_Compact,    (intptr_t)&gSizeIInfo        },
-    { offsetof(FixedPageUI, gradientColors),  Type_ColorArray, NULL                         },
+    { offsetof(FixedPageUI, textColor),                  Type_Color,      0x000000                     },
+    { offsetof(FixedPageUI, backgroundColor),            Type_Color,      0xffffff                     },
+    { offsetof(FixedPageUI, selectionColor),             Type_Color,      0x0cfcf5                     },
+    { offsetof(FixedPageUI, showScrollBarsInFullScreen), Type_Bool,       true                         },
+    { offsetof(FixedPageUI, windowMargin),               Type_Compact,    (intptr_t)&gWindowMarginInfo },
+    { offsetof(FixedPageUI, pageSpacing),                Type_Compact,    (intptr_t)&gSizeIInfo        },
+    { offsetof(FixedPageUI, gradientColors),             Type_ColorArray, NULL                         },
 };
-static const StructInfo gFixedPageUIInfo = { sizeof(FixedPageUI), 6, gFixedPageUIFields, "TextColor\0BackgroundColor\0SelectionColor\0WindowMargin\0PageSpacing\0GradientColors" };
+static const StructInfo gFixedPageUIInfo = { sizeof(FixedPageUI), 7, gFixedPageUIFields, "TextColor\0BackgroundColor\0SelectionColor\0ShowScrollBarsInFullScreen\0WindowMargin\0PageSpacing\0GradientColors" };
 
 static const FieldInfo gEbookUIFields[] = {
     { offsetof(EbookUI, fontName),        Type_String, (intptr_t)L"Georgia" },

--- a/src/SumatraPDF.cpp
+++ b/src/SumatraPDF.cpp
@@ -1003,6 +1003,7 @@ static bool LoadDocIntoWindow(LoadArgs& args, PasswordUI *pwdUI, DisplayState *s
             // tell UI Automation about content change
             if (win->uia_provider)
                 win->uia_provider->OnDocumentLoad(dm);
+            win->ctrl->SetFullScreenMode(win->isFullScreen);
         }
         else if (win->AsChm()) {
             win->ctrl->SetDisplayMode(displayMode);
@@ -3185,6 +3186,8 @@ static void EnterFullScreen(WindowInfo& win, bool presentation)
 
     if (presentation)
         win.ctrl->SetPresentationMode(true);
+    else if (win.ctrl != NULL)
+        win.ctrl->SetFullScreenMode(true);
 
     // Make sure that no toolbar/sidebar keeps the focus
     SetFocus(win.hwndFrame);
@@ -3201,8 +3204,12 @@ static void ExitFullScreen(WindowInfo& win)
         win.ctrl->SetPresentationMode(false);
         win.presentation = PM_DISABLED;
     }
-    else
+    else if (!wasPresentation){
         win.isFullScreen = false;
+        if (win.ctrl != NULL){
+            win.ctrl->SetFullScreenMode(false);
+        }
+    }
 
     if (wasPresentation) {
         KillTimer(win.hwndCanvas, HIDE_CURSOR_TIMER_ID);


### PR DESCRIPTION
In the advanced options there is a new field, FixedPageUI ->
ShowScrollBarsInFullScreen which is set to true by default. Unless this
is set to false then this changeset will have no effect. If it is set to
false then when full screen view is entered, with a zoom level like fit
content which usually requires scroll bars, then the pages will occupy
the entire screen area rather than the screen area minus scroll bars and
adding scroll bars. This is useful because presentation view does not
support facing pages.